### PR TITLE
Feat/anonymous dataset detail

### DIFF
--- a/backend/apps/api/dataset/serializers/dataset_read.py
+++ b/backend/apps/api/dataset/serializers/dataset_read.py
@@ -57,8 +57,22 @@ class DatasetDetailSerializer(serializers.ModelSerializer):
 
 
 class AnonymousDatasetDetailSerializer(serializers.ModelSerializer):
+    status = serializers.ChoiceField(
+        choices=Dataset.Status.choices,
+        read_only=True,
+    )
+
+    visibility = serializers.ChoiceField(
+        choices=Dataset.Visibility.choices,
+        read_only=True,
+    )
+
     schema = DatasetSchemaSerializer()
-    parse_result = ParseResultSerializer(required=False, allow_null=True)
+
+    parse_result = ParseResultSerializer(
+        required=False,
+        allow_null=True,
+    )
 
     class Meta:
         model = Dataset

--- a/backend/schema.json
+++ b/backend/schema.json
@@ -1478,7 +1478,12 @@
                         "maxLength": 255
                     },
                     "status": {
-                        "$ref": "#/components/schemas/StatusEnum"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StatusEnum"
+                            }
+                        ],
+                        "readOnly": true
                     },
                     "created_at": {
                         "type": "string",
@@ -1497,7 +1502,12 @@
                         "nullable": true
                     },
                     "visibility": {
-                        "$ref": "#/components/schemas/VisibilityEnum"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/VisibilityEnum"
+                            }
+                        ],
+                        "readOnly": true
                     },
                     "expires_at": {
                         "type": "string",
@@ -1510,7 +1520,9 @@
                     "created_at",
                     "id",
                     "name",
-                    "schema"
+                    "schema",
+                    "status",
+                    "visibility"
                 ]
             },
             "DatasetCreate": {

--- a/frontend/app/(site)/anonymous/[id]/page.tsx
+++ b/frontend/app/(site)/anonymous/[id]/page.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import { PageLayout } from "@/components/layout";
+import { AnonymousDatasetDetail } from "@/features/datasets/detail/components/AnonymousDatasetDetail";
+
+export default function AnonymousDatasetDetailPage() {
+  const { id } = useParams<{ id: string }>();
+
+  if (!id) return null;
+
+  return (
+    <PageLayout
+      title="Dataset 詳細"
+      description="アップロードした Dataset の詳細情報を確認できます"
+    >
+      <AnonymousDatasetDetail id={id} />
+    </PageLayout>
+  );
+}

--- a/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail .ts
+++ b/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail .ts
@@ -1,0 +1,10 @@
+import { apiClient } from "@/features/auth/api/apiClient";
+import type { DatasetDetailResponse } from "@/features/datasets/types/dataset";
+
+export const fetchAnonymousDatasetDetail = async (
+  id: string,
+): Promise<DatasetDetailResponse> => {
+  const { data } = await apiClient.get(`/datasets/anonymous/${id}/`);
+
+  return data;
+};

--- a/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail.ts
+++ b/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail.ts
@@ -1,9 +1,9 @@
 import { apiClient } from "@/features/auth/api/apiClient";
-import type { DatasetDetailResponse } from "@/features/datasets/types/dataset";
+import type { AnonymousDatasetDetailResponse } from "@/features/datasets/types/dataset";
 
 export const fetchAnonymousDatasetDetail = async (
   id: string,
-): Promise<DatasetDetailResponse> => {
+): Promise<AnonymousDatasetDetailResponse> => {
   const { data } = await apiClient.get(`/datasets/anonymous/${id}/`);
 
   return data;

--- a/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
+++ b/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
@@ -24,7 +24,7 @@ export function AnonymousDatasetDetail({ id }: Props) {
     isLoading,
     error,
   } = useQuery({
-    queryKey: datasetKeys.detail(id),
+    queryKey: datasetKeys.anonymousDetail(id),
     queryFn: () => fetchAnonymousDatasetDetail(id),
     enabled: !!id,
   });

--- a/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
+++ b/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronLeft } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+
+import { Loading } from "@/components/common";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+
+import { fetchAnonymousDatasetDetail } from "@/features/datasets/detail/api/fetchAnonymousDatasetDetail";
+import { DatasetSchemaView } from "@/features/datasets/detail/components/DatasetSchema";
+import { DatasetBadge } from "@/features/datasets/components/DatasetBadge";
+import { DatasetVisibilityBadge } from "@/features/datasets/components/DatasetVisibilityBadge";
+import { datasetKeys } from "@/features/datasets/queryKeys";
+
+type Props = {
+  id: string;
+};
+
+export function AnonymousDatasetDetail({ id }: Props) {
+  const {
+    data: dataset,
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: datasetKeys.detail(id),
+    queryFn: () => fetchAnonymousDatasetDetail(id),
+    enabled: !!id,
+  });
+
+  if (isLoading) {
+    return <Loading message="Datasetを読み込み中..." />;
+  }
+
+  if (error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Datasetの取得に失敗しました</AlertTitle>
+        <AlertDescription>{error.message}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!dataset) {
+    return <p className="text-sm text-gray-500">Datasetが見つかりません。</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 戻るボタン */}
+      <Link href="/">
+        <Button variant="outline" size="sm">
+          <ChevronLeft className="w-4 h-4 mr-2" />
+          トップへ戻る
+        </Button>
+      </Link>
+
+      {/* ヘッダー */}
+      <div className="space-y-1">
+        <h1 className="text-2xl font-semibold">{dataset.name}</h1>
+
+        <p className="text-sm text-gray-500">
+          作成日: {new Date(dataset.created_at).toLocaleString()}
+        </p>
+
+        {dataset.expires_at && (
+          <p className="text-sm text-orange-600">
+            有効期限: {new Date(dataset.expires_at).toLocaleString()}
+          </p>
+        )}
+      </div>
+
+      {/* ステータス */}
+      <div className="flex items-center gap-2">
+        <DatasetBadge
+          status={dataset.status}
+          message={dataset.parse_result?.message}
+        />
+
+        <DatasetVisibilityBadge visibility={dataset.visibility} />
+      </div>
+
+      {/* Schema */}
+      {dataset.status === "parsed" && (
+        <div>
+          <h2 className="text-lg font-medium">データ構造</h2>
+
+          <DatasetSchemaView schema={dataset.schema} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/features/datasets/queryKeys.ts
+++ b/frontend/features/datasets/queryKeys.ts
@@ -7,15 +7,22 @@ export const datasetKeys = {
 
   entityComparison: (id: string, metric: string) =>
     [...datasetKeys.all, "entityComparison", id, metric] as const,
+
   meta: (id: string) => [...datasetKeys.all, "meta", id] as const,
 
   publicList: () => [...datasetKeys.all, "public"] as const,
+
   publicDetail: (id: string) =>
     [...datasetKeys.all, "publicDetail", id] as const,
+
   publicDataPoints: (id: string) =>
     [...datasetKeys.all, "publicDataPoints", id] as const,
 
   publicEntityComparison: (id: string, metric: string) =>
     [...datasetKeys.all, "publicEntityComparison", id, metric] as const,
+
   publicMeta: (id: string) => [...datasetKeys.all, "publicMeta", id] as const,
+
+  anonymousDetail: (id: string) =>
+    [...datasetKeys.all, "anonymousDetail", id] as const,
 };

--- a/frontend/features/datasets/types/dataset.ts
+++ b/frontend/features/datasets/types/dataset.ts
@@ -35,6 +35,9 @@ export type DatasetListResponse =
 export type DatasetDetailResponse =
   paths["/api/v1/datasets/{id}/"]["get"]["responses"][200]["content"]["application/json"];
 
+export type AnonymousDatasetDetailResponse =
+  paths["/api/v1/datasets/anonymous/{id}/"]["get"]["responses"][200]["content"]["application/json"];
+
 // =============================
 // Common
 // =============================

--- a/frontend/types/api.d.ts
+++ b/frontend/types/api.d.ts
@@ -569,12 +569,12 @@ export interface components {
         AnonymousDatasetDetail: {
             readonly id: number;
             name: string;
-            status?: components["schemas"]["StatusEnum"];
+            readonly status: components["schemas"]["StatusEnum"];
             /** Format: date-time */
             readonly created_at: string;
             schema: components["schemas"]["DatasetSchema"];
             parse_result?: components["schemas"]["ParseResult"] | null;
-            visibility?: components["schemas"]["VisibilityEnum"];
+            readonly visibility: components["schemas"]["VisibilityEnum"];
             /**
              * Format: date-time
              * @description 匿名データの有効期限（任意）


### PR DESCRIPTION
# 変更点
- 匿名ユーザー用のデータセット詳細コンポーネントを追加

## 備考
次回のPRでは、`Dataset`モデルに`public_id`フィールドを追加し、URL設計などに内部IDを用いないように修正する予定。 