### PR TITLE
Feat/anonymous public

### DIFF
--- a/backend/apps/api/dataset/serializers/dataset_read.py
+++ b/backend/apps/api/dataset/serializers/dataset_read.py
@@ -77,7 +77,7 @@ class AnonymousDatasetDetailSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = [
-            "id",
+            "public_id",
             "name",
             "status",
             "created_at",

--- a/backend/apps/api/dataset/serializers/dataset_write.py
+++ b/backend/apps/api/dataset/serializers/dataset_write.py
@@ -7,7 +7,6 @@ class BaseDatasetCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Dataset
         fields = [
-            "id",
             "name",
             "source_file",
             "schema",
@@ -52,6 +51,8 @@ class DatasetCreateSerializer(BaseDatasetCreateSerializer):
 
     class Meta(BaseDatasetCreateSerializer.Meta):
         fields = BaseDatasetCreateSerializer.Meta.fields + [
+            "id",
+            "public_id",
             "owner",
             "status",
             "created_at",
@@ -67,4 +68,6 @@ class DatasetVisibilitySerializer(serializers.ModelSerializer):
 
 class AnonymousDatasetCreateSerializer(BaseDatasetCreateSerializer):
     class Meta(BaseDatasetCreateSerializer.Meta):
-        fields = BaseDatasetCreateSerializer.Meta.fields
+        fields = BaseDatasetCreateSerializer.Meta.fields + [
+            "public_id",
+        ]

--- a/backend/apps/api/dataset/tests/views/test_dataset_read.py
+++ b/backend/apps/api/dataset/tests/views/test_dataset_read.py
@@ -26,13 +26,13 @@ class TestAnonymousDatasetDetailAPIView:
 
         url = reverse(
             "dataset:anonymous-detail",
-            kwargs={"pk": dataset.pk},
+            kwargs={"public_id": dataset.public_id},
         )
 
         response = api_client.get(url)
 
         assert response.status_code == 200
-        assert response.data["id"] == dataset.pk
+        assert response.data["public_id"] == str(dataset.public_id)
         assert response.data["name"] == "Anonymous Dataset"
 
     def test_without_cookie_returns_404(self, api_client):
@@ -47,7 +47,7 @@ class TestAnonymousDatasetDetailAPIView:
 
         url = reverse(
             "dataset:anonymous-detail",
-            kwargs={"pk": dataset.pk},
+            kwargs={"public_id": dataset.public_id},
         )
 
         response = api_client.get(url)
@@ -68,7 +68,7 @@ class TestAnonymousDatasetDetailAPIView:
 
         url = reverse(
             "dataset:anonymous-detail",
-            kwargs={"pk": dataset.pk},
+            kwargs={"public_id": dataset.public_id},
         )
 
         response = api_client.get(url)
@@ -80,7 +80,7 @@ class TestAnonymousDatasetDetailAPIView:
 
         url = reverse(
             "dataset:anonymous-detail",
-            kwargs={"pk": 999999},
+            kwargs={"public_id": uuid.uuid4()},
         )
 
         response = api_client.get(url)

--- a/backend/apps/api/dataset/tests/views/test_dataset_write.py
+++ b/backend/apps/api/dataset/tests/views/test_dataset_write.py
@@ -157,8 +157,8 @@ class TestDatasetAnonymousCreateAPIView:
 
         assert response.status_code == status.HTTP_201_CREATED  # type: ignore
 
-        dataset_id = response.data["id"]  # type: ignore
-        dataset = Dataset.objects.get(pk=dataset_id)
+        dataset_public_id = response.data["public_id"]  # type: ignore
+        dataset = Dataset.objects.get(public_id=dataset_public_id)
 
         assert dataset.owner is None
         assert dataset.anonymous_id is not None
@@ -211,8 +211,8 @@ class TestDatasetAnonymousCreateAPIView:
 
         assert response.status_code == status.HTTP_201_CREATED  # type: ignore
 
-        dataset_id = response.data["id"]  # type: ignore
-        dataset = Dataset.objects.get(pk=dataset_id)
+        dataset_public_id = response.data["public_id"]  # type: ignore
+        dataset = Dataset.objects.get(public_id=dataset_public_id)
 
         assert str(dataset.anonymous_id) == existing_id
 

--- a/backend/apps/api/dataset/urls.py
+++ b/backend/apps/api/dataset/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     ),
     path("<int:pk>/", DatasetDetailAPIView.as_view(), name="detail"),
     path(
-        "anonymous/<int:pk>/",
+        "anonymous/<uuid:public_id>/",
         AnonymousDatasetDetailAPIView.as_view(),
         name="anonymous-detail",
     ),

--- a/backend/apps/api/dataset/views/dataset_read.py
+++ b/backend/apps/api/dataset/views/dataset_read.py
@@ -40,6 +40,7 @@ class DatasetDetailAPIView(generics.RetrieveAPIView):
 class AnonymousDatasetDetailAPIView(generics.RetrieveAPIView):
     serializer_class = AnonymousDatasetDetailSerializer
     permission_classes = [AllowAny]
+    lookup_field = "public_id"
 
     def get_queryset(self):
         anonymous_id = get_anonymous_id(self.request)

--- a/backend/schema.json
+++ b/backend/schema.json
@@ -1446,10 +1446,6 @@
             "AnonymousDatasetCreate": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
                     "name": {
                         "type": "string",
                         "maxLength": 255
@@ -1458,11 +1454,16 @@
                         "type": "string",
                         "format": "uri"
                     },
-                    "schema": {}
+                    "schema": {},
+                    "public_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true
+                    }
                 },
                 "required": [
-                    "id",
                     "name",
+                    "public_id",
                     "schema",
                     "source_file"
                 ]
@@ -1530,10 +1531,6 @@
             "DatasetCreate": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "integer",
-                        "readOnly": true
-                    },
                     "name": {
                         "type": "string",
                         "maxLength": 255
@@ -1543,6 +1540,15 @@
                         "format": "uri"
                     },
                     "schema": {},
+                    "id": {
+                        "type": "integer",
+                        "readOnly": true
+                    },
+                    "public_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true
+                    },
                     "owner": {
                         "type": "integer",
                         "readOnly": true
@@ -1562,6 +1568,7 @@
                     "id",
                     "name",
                     "owner",
+                    "public_id",
                     "schema",
                     "source_file",
                     "status"

--- a/backend/schema.json
+++ b/backend/schema.json
@@ -363,15 +363,16 @@
                 }
             }
         },
-        "/api/v1/datasets/anonymous/{id}/": {
+        "/api/v1/datasets/anonymous/{public_id}/": {
             "get": {
                 "operationId": "datasets_anonymous_retrieve",
                 "parameters": [
                     {
                         "in": "path",
-                        "name": "id",
+                        "name": "public_id",
                         "schema": {
-                            "type": "integer"
+                            "type": "string",
+                            "format": "uuid"
                         },
                         "required": true
                     }
@@ -1469,8 +1470,9 @@
             "AnonymousDatasetDetail": {
                 "type": "object",
                 "properties": {
-                    "id": {
-                        "type": "integer",
+                    "public_id": {
+                        "type": "string",
+                        "format": "uuid",
                         "readOnly": true
                     },
                     "name": {
@@ -1518,8 +1520,8 @@
                 },
                 "required": [
                     "created_at",
-                    "id",
                     "name",
+                    "public_id",
                     "schema",
                     "status",
                     "visibility"

--- a/frontend/app/(site)/anonymous/[publicId]/page.tsx
+++ b/frontend/app/(site)/anonymous/[publicId]/page.tsx
@@ -1,20 +1,21 @@
 "use client";
 
 import { useParams } from "next/navigation";
+
 import { PageLayout } from "@/components/layout";
 import { AnonymousDatasetDetail } from "@/features/datasets/detail/components/AnonymousDatasetDetail";
 
 export default function AnonymousDatasetDetailPage() {
-  const { id } = useParams<{ id: string }>();
+  const { publicId } = useParams<{ publicId: string }>();
 
-  if (!id) return null;
+  if (!publicId) return null;
 
   return (
     <PageLayout
       title="Dataset 詳細"
       description="アップロードした Dataset の詳細情報を確認できます"
     >
-      <AnonymousDatasetDetail id={id} />
+      <AnonymousDatasetDetail publicId={publicId} />
     </PageLayout>
   );
 }

--- a/frontend/features/datasets/create/components/AnonymousDatasetUploadForm.tsx
+++ b/frontend/features/datasets/create/components/AnonymousDatasetUploadForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 import { useMutation } from "@tanstack/react-query";
 
@@ -15,6 +16,8 @@ import { useCsvFile } from "@/features/datasets/create/hooks/useCsvFile";
 import { uploadAnonymousDataset } from "@/features/datasets/create/api/uploadDataset";
 
 export function AnonymousDatasetUploadForm() {
+  const router = useRouter();
+
   const {
     file,
     headers,
@@ -42,9 +45,7 @@ export function AnonymousDatasetUploadForm() {
         text: `アップロード成功: ${data.name}`,
       });
 
-      // TODO:
-      // router.push(`/datasets/${data.id}`)
-      // などへ遷移してもよい
+      router.push(`/anonymous/${data.public_id}`);
     },
 
     onError: (error: unknown) => {

--- a/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail.ts
+++ b/frontend/features/datasets/detail/api/fetchAnonymousDatasetDetail.ts
@@ -2,9 +2,9 @@ import { apiClient } from "@/features/auth/api/apiClient";
 import type { AnonymousDatasetDetailResponse } from "@/features/datasets/types/dataset";
 
 export const fetchAnonymousDatasetDetail = async (
-  id: string,
+  publicId: string,
 ): Promise<AnonymousDatasetDetailResponse> => {
-  const { data } = await apiClient.get(`/datasets/anonymous/${id}/`);
+  const { data } = await apiClient.get(`/datasets/anonymous/${publicId}/`);
 
   return data;
 };

--- a/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
+++ b/frontend/features/datasets/detail/components/AnonymousDatasetDetail.tsx
@@ -15,18 +15,18 @@ import { DatasetVisibilityBadge } from "@/features/datasets/components/DatasetVi
 import { datasetKeys } from "@/features/datasets/queryKeys";
 
 type Props = {
-  id: string;
+  publicId: string;
 };
 
-export function AnonymousDatasetDetail({ id }: Props) {
+export function AnonymousDatasetDetail({ publicId }: Props) {
   const {
     data: dataset,
     isLoading,
     error,
   } = useQuery({
-    queryKey: datasetKeys.anonymousDetail(id),
-    queryFn: () => fetchAnonymousDatasetDetail(id),
-    enabled: !!id,
+    queryKey: datasetKeys.anonymousDetail(publicId),
+    queryFn: () => fetchAnonymousDatasetDetail(publicId),
+    enabled: !!publicId,
   });
 
   if (isLoading) {

--- a/frontend/features/datasets/types/dataset.ts
+++ b/frontend/features/datasets/types/dataset.ts
@@ -36,7 +36,7 @@ export type DatasetDetailResponse =
   paths["/api/v1/datasets/{id}/"]["get"]["responses"][200]["content"]["application/json"];
 
 export type AnonymousDatasetDetailResponse =
-  paths["/api/v1/datasets/anonymous/{id}/"]["get"]["responses"][200]["content"]["application/json"];
+  paths["/api/v1/datasets/anonymous/{public_id}/"]["get"]["responses"][200]["content"]["application/json"];
 
 // =============================
 // Common

--- a/frontend/types/api.d.ts
+++ b/frontend/types/api.d.ts
@@ -112,7 +112,7 @@ export interface paths {
         patch: operations["datasets_visibility_partial_update"];
         trace?: never;
     };
-    "/api/v1/datasets/anonymous/{id}/": {
+    "/api/v1/datasets/anonymous/{public_id}/": {
         parameters: {
             query?: never;
             header?: never;
@@ -567,7 +567,8 @@ export interface components {
             schema: unknown;
         };
         AnonymousDatasetDetail: {
-            readonly id: number;
+            /** Format: uuid */
+            readonly public_id: string;
             name: string;
             readonly status: components["schemas"]["StatusEnum"];
             /** Format: date-time */
@@ -967,7 +968,7 @@ export interface operations {
             query?: never;
             header?: never;
             path: {
-                id: number;
+                public_id: string;
             };
             cookie?: never;
         };

--- a/frontend/types/api.d.ts
+++ b/frontend/types/api.d.ts
@@ -560,11 +560,12 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         AnonymousDatasetCreate: {
-            readonly id: number;
             name: string;
             /** Format: uri */
             source_file: string;
             schema: unknown;
+            /** Format: uuid */
+            readonly public_id: string;
         };
         AnonymousDatasetDetail: {
             /** Format: uuid */
@@ -583,11 +584,13 @@ export interface components {
             expires_at?: string | null;
         };
         DatasetCreate: {
-            readonly id: number;
             name: string;
             /** Format: uri */
             source_file: string;
             schema: unknown;
+            readonly id: number;
+            /** Format: uuid */
+            readonly public_id: string;
             readonly owner: number;
             readonly status: string;
             /** Format: date-time */


### PR DESCRIPTION
# 変更点
- 匿名ユーザー用のデータセット詳細API、画面で`public_id`を使うように変更
- UXの改善：匿名ユーザーがデータセットをアップロードし、成功したら詳細画面に遷移するように変更