### PR TITLE
Feat/anonymous dataset expiration

### DIFF
--- a/backend/apps/api/dataset/tests/views/test_datapoint.py
+++ b/backend/apps/api/dataset/tests/views/test_datapoint.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from rest_framework import status
 
+from apps.core.constants import ANONYMOUS_ID_COOKIE_NAME
 from apps.dataset.models import DataPoint, Dataset
 from apps.dataset.services.ingestion.csv_parser import parse_row_time
 
@@ -203,6 +204,122 @@ class TestDatasetMetaAPIView:
         assert res.status_code == 200
         assert res.data["entities"] == []
         assert res.data["metrics"] == []
+
+
+@pytest.mark.django_db
+class TestAnonymousDatasetTimeSeriesAPIView:
+
+    def test_returns_structured_data(
+        self,
+        anonymous_api_client,
+        anonymous_dataset,
+    ):
+
+        DataPoint.objects.create(
+            dataset=anonymous_dataset,
+            entity="A",
+            metric="value",
+            raw_time="2026-03-13T00:00:00Z",
+            time=parse_row_time("2026-03-13T00:00:00Z"),
+            value=1,
+            order_index=0,
+        )
+
+        DataPoint.objects.create(
+            dataset=anonymous_dataset,
+            entity="A",
+            metric="anomaly",
+            raw_time="2026-03-13T00:00:00Z",
+            time=parse_row_time("2026-03-13T00:00:00Z"),
+            value=0.1,
+            order_index=1,
+        )
+
+        DataPoint.objects.create(
+            dataset=anonymous_dataset,
+            entity="B",
+            metric="value",
+            raw_time="2026-03-13T01:00:00Z",
+            time=parse_row_time("2026-03-13T01:00:00Z"),
+            value=2,
+            order_index=0,
+        )
+
+        url = reverse(
+            "dataset:anonymous-timeseries",
+            kwargs={"public_id": anonymous_dataset.public_id},
+        )
+
+        res = anonymous_api_client.get(url)
+
+        assert res.status_code == 200
+
+    def test_returns_404_for_other_anonymous_user(
+        self,
+        anonymous_api_client,
+        another_anonymous_dataset,
+    ):
+        """他のanonymousユーザーはアクセス不可"""
+
+        url = reverse(
+            "dataset:anonymous-timeseries",
+            kwargs={"public_id": another_anonymous_dataset.public_id},
+        )
+
+        res = anonymous_api_client.get(url)
+
+        assert res.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_empty_dataset_returns_empty_dict(
+        self,
+        anonymous_api_client,
+        anonymous_dataset,
+    ):
+        """データがない場合は空dict"""
+
+        url = reverse(
+            "dataset:anonymous-timeseries",
+            kwargs={"public_id": anonymous_dataset.public_id},
+        )
+
+        res = anonymous_api_client.get(url)
+
+        assert res.status_code == status.HTTP_200_OK
+        assert res.data == {}
+
+    def test_missing_cookie_returns_403(
+        self,
+        api_client,
+        anonymous_dataset,
+    ):
+        """cookieなしは拒否"""
+
+        url = reverse(
+            "dataset:anonymous-timeseries",
+            kwargs={"public_id": anonymous_dataset.public_id},
+        )
+
+        res = api_client.get(url)
+
+        assert res.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_invalid_cookie_returns_403(
+        self,
+        api_client,
+        anonymous_dataset,
+    ):
+        """不正UUID cookieは拒否"""
+
+        api_client.cookies[ANONYMOUS_ID_COOKIE_NAME] = "invalid-uuid"
+
+        url = reverse(
+            "dataset:anonymous-timeseries",
+            kwargs={"public_id": anonymous_dataset.public_id},
+        )
+
+        res = api_client.get(url)
+
+        assert res.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db

--- a/backend/apps/api/dataset/urls.py
+++ b/backend/apps/api/dataset/urls.py
@@ -10,6 +10,7 @@ from apps.api.dataset.views.dataset_read import (
     PublicDatasetListAPIView,
 )
 from apps.api.dataset.views.dataset_timeseries import (
+    AnonymousDatasetTimeSeriesAPIView,
     DatasetEntityComparisonAPIView,
     DatasetMetaAPIView,
     DatasetTimeSeriesAPIView,
@@ -45,6 +46,11 @@ urlpatterns = [
         name="anonymous-detail",
     ),
     path("<int:pk>/timeseries/", DatasetTimeSeriesAPIView.as_view(), name="timeseries"),
+    path(
+        "anonymous/<uuid:public_id>/timeseries/",
+        AnonymousDatasetTimeSeriesAPIView.as_view(),
+        name="anonymous-timeseries",
+    ),
     path(
         "<int:pk>/timeseries/entity/",
         DatasetEntityComparisonAPIView.as_view(),

--- a/backend/apps/api/dataset/views/dataset_timeseries.py
+++ b/backend/apps/api/dataset/views/dataset_timeseries.py
@@ -1,9 +1,8 @@
 from uuid import UUID
 
 from django.shortcuts import get_object_or_404
-from django.utils import timezone
 from rest_framework import status
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response

--- a/backend/apps/api/dataset/views/dataset_timeseries.py
+++ b/backend/apps/api/dataset/views/dataset_timeseries.py
@@ -109,7 +109,7 @@ class AnonymousDatasetTimeSeriesAPIView(APIView):
         tags=["Dataset"],
         responses=TimeSeriesDataByEntity,
     )
-    def get(self, request, pk: int):
+    def get(self, request, public_id):
         anonymous_id = request.COOKIES.get("anonymous_id")
 
         if not anonymous_id:
@@ -122,7 +122,7 @@ class AnonymousDatasetTimeSeriesAPIView(APIView):
 
         dataset = get_object_or_404(
             Dataset,
-            pk=pk,
+            public_id=public_id,
             anonymous_id=anonymous_uuid,
         )
 

--- a/backend/apps/api/dataset/views/dataset_timeseries.py
+++ b/backend/apps/api/dataset/views/dataset_timeseries.py
@@ -125,10 +125,6 @@ class AnonymousDatasetTimeSeriesAPIView(APIView):
             anonymous_id=anonymous_uuid,
         )
 
-        # 期限チェック（ここかなり重要）
-        if dataset.expires_at and dataset.expires_at < timezone.now():
-            raise NotFound("dataset expired")
-
         # DataPoint取得
         data_qs = dataset.data_points.all().order_by("entity", "time", "order_index")  # type: ignore
 

--- a/backend/apps/api/dataset/views/dataset_timeseries.py
+++ b/backend/apps/api/dataset/views/dataset_timeseries.py
@@ -1,5 +1,9 @@
+from uuid import UUID
+
 from django.shortcuts import get_object_or_404
+from django.utils import timezone
 from rest_framework import status
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import GenericAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
@@ -90,6 +94,47 @@ class DatasetMetaAPIView(GenericAPIView):
 
         serializer = self.get_serializer(instance=data)
         return Response(serializer.data)
+
+
+class AnonymousDatasetTimeSeriesAPIView(APIView):
+    """
+    anonymous_id に紐づく Dataset の時系列データを取得
+    Recharts 形式で返す
+    """
+
+    @schema(
+        summary="匿名ユーザー Dataset の時系列データ取得",
+        description="anonymous_id に紐づく Dataset の DataPoint を entity ごとに整理して返す",
+        tags=["Dataset"],
+        responses=TimeSeriesDataByEntity,
+    )
+    def get(self, request, pk: int):
+        anonymous_id = request.COOKIES.get("anonymous_id")
+
+        if not anonymous_id:
+            raise PermissionDenied("anonymous_id is required")
+
+        try:
+            anonymous_uuid = UUID(anonymous_id)
+        except ValueError:
+            raise PermissionDenied("invalid anonymous_id")
+
+        dataset = get_object_or_404(
+            Dataset,
+            pk=pk,
+            anonymous_id=anonymous_uuid,
+        )
+
+        # 期限チェック（ここかなり重要）
+        if dataset.expires_at and dataset.expires_at < timezone.now():
+            raise NotFound("dataset expired")
+
+        # DataPoint取得
+        data_qs = dataset.data_points.all().order_by("entity", "time", "order_index")  # type: ignore
+
+        result = build_time_series_data(data_qs)
+
+        return Response(result, status=status.HTTP_200_OK)
 
 
 class PublicDatasetTimeSeriesAPIView(APIView):

--- a/backend/apps/api/dataset/views/dataset_timeseries.py
+++ b/backend/apps/api/dataset/views/dataset_timeseries.py
@@ -102,6 +102,8 @@ class AnonymousDatasetTimeSeriesAPIView(APIView):
     Recharts 形式で返す
     """
 
+    permission_classes = [AllowAny]
+
     @schema(
         summary="匿名ユーザー Dataset の時系列データ取得",
         description="anonymous_id に紐づく Dataset の DataPoint を entity ごとに整理して返す",

--- a/backend/apps/core/services/cookies.py
+++ b/backend/apps/core/services/cookies.py
@@ -1,18 +1,25 @@
+from uuid import UUID
+
 from django.conf import settings
 
 from apps.core.constants import ANONYMOUS_ID_COOKIE_NAME
 
 
-def set_anonymous_cookie(response, anonymous_id: str, created: bool):
+def set_anonymous_cookie(
+    response,
+    anonymous_id: UUID,
+    created: bool,
+):
     if not created:
         return response
 
     response.set_cookie(
         ANONYMOUS_ID_COOKIE_NAME,
-        anonymous_id,
+        str(anonymous_id),
         max_age=settings.COOKIE_MAX_AGE,
         httponly=True,
         samesite=settings.COOKIE_SAMESITE,
         secure=settings.COOKIE_SECURE,
     )
+
     return response

--- a/backend/apps/core/tests/services/test_cookies.py
+++ b/backend/apps/core/tests/services/test_cookies.py
@@ -1,3 +1,5 @@
+import uuid
+
 from django.http import HttpResponse
 
 from apps.core.constants import ANONYMOUS_ID_COOKIE_NAME
@@ -10,27 +12,31 @@ class TestSetAnonymousCookie:
         settings.COOKIE_SAMESITE = "Lax"
         settings.COOKIE_SECURE = True
 
+        anonymous_id = uuid.uuid4()
+
         response = HttpResponse()
 
         response = set_anonymous_cookie(
             response=response,
-            anonymous_id="anon-123",
+            anonymous_id=anonymous_id,
             created=True,
         )
 
         cookie = response.cookies[ANONYMOUS_ID_COOKIE_NAME]
 
-        assert cookie.value == "anon-123"
+        assert cookie.value == str(anonymous_id)
         assert cookie["max-age"] == 3600
         assert cookie["samesite"] == "Lax"
         assert cookie["secure"]
 
     def test_does_not_set_cookie_when_not_created(self):
+        anonymous_id = uuid.uuid4()
+
         response = HttpResponse()
 
         response = set_anonymous_cookie(
             response=response,
-            anonymous_id="anon-123",
+            anonymous_id=anonymous_id,
             created=False,
         )
 

--- a/backend/apps/dataset/models.py
+++ b/backend/apps/dataset/models.py
@@ -143,6 +143,12 @@ class Dataset(models.Model):
         storage = self.source_file.storage
         return storage.url(self.source_file.name)
 
+    def delete(self, *args, **kwargs):
+        if self.source_file:
+            self.source_file.delete(save=False)
+
+        super().delete(*args, **kwargs)
+
 
 class DataPoint(models.Model):
     DEFAULT_ENTITY = "__default__"

--- a/backend/apps/dataset/services/application/build_dataset.py
+++ b/backend/apps/dataset/services/application/build_dataset.py
@@ -1,3 +1,7 @@
+from datetime import timedelta
+
+from django.conf import settings
+from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.dataset.models import Dataset
@@ -16,13 +20,15 @@ def create_dataset(
     """
     Dataset を作成するサービス関数。
 
-    - CSV × schema の整合性チェック
+    Responsibilities:
     - owner / anonymous_id の排他制御
-    - データベース保存
-    - 非同期ジョブ投入
+    - CSV validation
+    - expires_at の設定
+    - Dataset 作成
+    - 非同期解析ジョブ投入
     """
 
-    # --- owner / anonymous_id の排他チェック ---
+    # --- owner / anonymous_id validation ---
     if bool(owner) == bool(anonymous_id):
         raise ValidationError("Exactly one of owner or anonymous_id must be provided.")
 
@@ -32,6 +38,14 @@ def create_dataset(
     except ValueError as e:
         raise ValidationError(str(e))
 
+    # --- expiration policy ---
+    expires_at = None
+
+    if anonymous_id is not None:
+        expires_at = timezone.now() + timedelta(
+            days=settings.ANONYMOUS_DATASET_TTL_DAYS
+        )
+
     # --- create dataset ---
     dataset = Dataset.objects.create(
         owner=owner,
@@ -39,9 +53,10 @@ def create_dataset(
         name=name,
         source_file=source_file,
         schema=schema,
+        expires_at=expires_at,
     )
 
     # --- async processing ---
-    enqueue_parse_dataset(dataset.id)  # type: ignore
+    enqueue_parse_dataset(dataset.id)  # type: ignore[arg-type]
 
     return dataset

--- a/backend/apps/dataset/services/application/delete_expired_datasets.py
+++ b/backend/apps/dataset/services/application/delete_expired_datasets.py
@@ -1,0 +1,18 @@
+from django.utils import timezone
+
+from apps.dataset.models import Dataset
+
+
+def delete_expired_anonymous_datasets() -> int:
+    expired_datasets = Dataset.objects.filter(
+        owner__isnull=True,
+        expires_at__isnull=False,
+        expires_at__lt=timezone.now(),
+    )
+
+    count = expired_datasets.count()
+
+    for dataset in expired_datasets:
+        dataset.delete()
+
+    return count

--- a/backend/apps/dataset/tests/test_models.py
+++ b/backend/apps/dataset/tests/test_models.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 
 import pytest
@@ -230,6 +231,42 @@ class TestDatasetModel:
         dataset.delete()
 
         assert DataPoint.objects.count() == 0
+
+
+@pytest.mark.django_db
+class TestDatasetDelete:
+
+    def test_delete_removes_source_file(self, user, tmp_path, settings):
+        """
+        Dataset.delete() で source_file も削除される
+        """
+
+        settings.MEDIA_ROOT = tmp_path
+
+        dummy_file = SimpleUploadedFile(
+            "test.csv",
+            b"col1,col2\n1,2",
+        )
+
+        dataset = Dataset.objects.create(
+            owner=user,
+            name="dataset",
+            source_file=dummy_file,
+            schema={"time": "year", "metrics": ["value"]},
+        )
+
+        file_path = dataset.source_file.path
+
+        # ファイル存在確認
+        assert os.path.exists(file_path)
+
+        dataset.delete()
+
+        # ファイルも消えている
+        assert not os.path.exists(file_path)
+
+        # DBレコードも消えている
+        assert Dataset.objects.count() == 0
 
 
 @pytest.mark.django_db

--- a/backend/apps/dataset/tests/test_services/application/test_delete_expired_datasets.py
+++ b/backend/apps/dataset/tests/test_services/application/test_delete_expired_datasets.py
@@ -1,0 +1,94 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from apps.dataset.models import Dataset
+from apps.dataset.services.application.delete_expired_datasets import (
+    delete_expired_anonymous_datasets,
+)
+
+
+@pytest.mark.django_db
+class TestDeleteExpiredAnonymousDatasets:
+
+    def test_delete_only_expired_anonymous_datasets(
+        self,
+        anonymous_id,
+        user,
+    ):
+        """
+        期限切れ匿名Datasetのみ削除される
+        """
+
+        expired_dataset = Dataset.objects.create(
+            name="expired",
+            anonymous_id=anonymous_id,
+            expires_at=timezone.now() - timedelta(days=1),
+            schema={
+                "time": "timestamp",
+                "metrics": ["value"],
+            },
+        )
+
+        not_expired_dataset = Dataset.objects.create(
+            name="not expired",
+            anonymous_id=anonymous_id,
+            expires_at=timezone.now() + timedelta(days=1),
+            schema={
+                "time": "timestamp",
+                "metrics": ["value"],
+            },
+        )
+
+        user_dataset = Dataset.objects.create(
+            name="user dataset",
+            owner=user,
+            expires_at=timezone.now() - timedelta(days=1),
+            schema={
+                "time": "timestamp",
+                "metrics": ["value"],
+            },
+        )
+
+        deleted_count = delete_expired_anonymous_datasets()
+
+        assert deleted_count == 1
+
+        assert not Dataset.objects.filter(pk=expired_dataset.pk).exists()
+
+        assert Dataset.objects.filter(pk=not_expired_dataset.pk).exists()
+
+        assert Dataset.objects.filter(pk=user_dataset.pk).exists()
+
+    def test_return_zero_when_no_expired_datasets(
+        self,
+        anonymous_dataset,
+    ):
+        """
+        削除対象がない場合は0を返す
+        """
+
+        anonymous_dataset.expires_at = timezone.now() + timedelta(days=1)
+        anonymous_dataset.save()
+
+        deleted_count = delete_expired_anonymous_datasets()
+
+        assert deleted_count == 0
+
+    def test_delete_expired_dataset_with_datapoints(
+        self,
+        anonymous_dataset,
+    ):
+        """
+        期限切れDataset削除時にDataPointもcascade削除される
+        """
+
+        anonymous_dataset.expires_at = timezone.now() - timedelta(days=1)
+        anonymous_dataset.save()
+
+        deleted_count = delete_expired_anonymous_datasets()
+
+        assert deleted_count == 1
+
+        assert Dataset.objects.count() == 0

--- a/backend/apps/dataset/tests/test_services/application/test_delete_expired_datasets.py
+++ b/backend/apps/dataset/tests/test_services/application/test_delete_expired_datasets.py
@@ -1,6 +1,8 @@
+import os
 from datetime import timedelta
 
 import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 
 from apps.dataset.models import Dataset
@@ -92,3 +94,41 @@ class TestDeleteExpiredAnonymousDatasets:
         assert deleted_count == 1
 
         assert Dataset.objects.count() == 0
+
+    def test_delete_expired_dataset_removes_source_file(
+        self,
+        anonymous_id,
+        tmp_path,
+        settings,
+    ):
+        """
+        cleanup時にsource_fileも削除される
+        """
+
+        settings.MEDIA_ROOT = tmp_path
+
+        dummy_file = SimpleUploadedFile(
+            "test.csv",
+            b"col1,col2\n1,2",
+        )
+
+        dataset = Dataset.objects.create(
+            name="expired",
+            anonymous_id=anonymous_id,
+            source_file=dummy_file,
+            expires_at=timezone.now() - timedelta(days=1),
+            schema={
+                "time": "timestamp",
+                "metrics": ["value"],
+            },
+        )
+
+        file_path = dataset.source_file.path
+
+        assert os.path.exists(file_path)
+
+        deleted_count = delete_expired_anonymous_datasets()
+
+        assert deleted_count == 1
+
+        assert not os.path.exists(file_path)

--- a/backend/apps/dataset/tests/test_services/test_dataset_service.py
+++ b/backend/apps/dataset/tests/test_services/test_dataset_service.py
@@ -1,7 +1,9 @@
 import uuid
+from datetime import timedelta
 
 import pytest
 from django.core.files.base import ContentFile
+from django.utils import timezone
 from rest_framework.exceptions import ValidationError
 
 from apps.dataset.models import Dataset
@@ -50,18 +52,22 @@ class TestCreateDatasetService:
 
         assert dataset.owner == user
         assert dataset.anonymous_id is None
+        assert dataset.expires_at is None
         assert dataset.name == "Test Dataset"
 
         mock_validate.assert_called_once_with(source_file, schema)
 
-        mock_enqueue.assert_called_once_with(dataset.id)  # type: ignore
+        mock_enqueue.assert_called_once_with(dataset.id)  # type: ignore[arg-type]
 
     def test_create_dataset_with_anonymous_id(
         self,
         mocker,
+        settings,
         source_file,
         schema,
     ):
+        settings.ANONYMOUS_DATASET_TTL_DAYS = 7
+
         mock_validate = mocker.patch(
             "apps.dataset.services.application.build_dataset.validate_csv_against_schema"
         )
@@ -72,6 +78,8 @@ class TestCreateDatasetService:
 
         anonymous_id = uuid.uuid4()
 
+        before_create = timezone.now()
+
         dataset = create_dataset(
             anonymous_id=anonymous_id,
             name="Anonymous Dataset",
@@ -79,15 +87,24 @@ class TestCreateDatasetService:
             schema=schema,
         )
 
+        after_create = timezone.now()
+
         assert Dataset.objects.filter(pk=dataset.pk).exists()
 
         assert dataset.owner is None
         assert dataset.anonymous_id == anonymous_id
         assert dataset.name == "Anonymous Dataset"
 
+        assert dataset.expires_at is not None
+
+        expected_min = before_create + timedelta(days=7)
+        expected_max = after_create + timedelta(days=7)
+
+        assert expected_min <= dataset.expires_at <= expected_max
+
         mock_validate.assert_called_once_with(source_file, schema)
 
-        mock_enqueue.assert_called_once_with(dataset.id)  # type: ignore
+        mock_enqueue.assert_called_once_with(dataset.id)  # type: ignore[arg-type]
 
     def test_create_dataset_validation_error(
         self,

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -347,3 +347,5 @@ LOGGING = {
 # ================================
 # App-specific settings
 # ================================
+
+ANONYMOUS_DATASET_TTL_DAYS = 7

--- a/backend/schema.json
+++ b/backend/schema.json
@@ -458,6 +458,63 @@
                 }
             }
         },
+        "/api/v1/datasets/anonymous/{public_id}/timeseries/": {
+            "get": {
+                "operationId": "datasets_anonymous_timeseries_retrieve",
+                "description": "anonymous_id に紐づく Dataset の DataPoint を entity ごとに整理して返す",
+                "summary": "匿名ユーザー Dataset の時系列データ取得",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "public_id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "Dataset"
+                ],
+                "security": [
+                    {
+                        "jwtAuth": []
+                    },
+                    {
+                        "jwtHeaderAuth": []
+                    },
+                    {
+                        "jwtCookieAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "object",
+                                            "description": "1つの時刻における metric データ",
+                                            "properties": {
+                                                "time": {
+                                                    "type": "string"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
         "/api/v1/datasets/anonymous/create/": {
             "post": {
                 "operationId": "datasets_anonymous_create_create",

--- a/frontend/types/api.d.ts
+++ b/frontend/types/api.d.ts
@@ -144,6 +144,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/datasets/anonymous/{public_id}/timeseries/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * 匿名ユーザー Dataset の時系列データ取得
+         * @description anonymous_id に紐づく Dataset の DataPoint を entity ごとに整理して返す
+         */
+        get: operations["datasets_anonymous_timeseries_retrieve"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/datasets/anonymous/create/": {
         parameters: {
             query?: never;
@@ -1046,6 +1066,31 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["AnonymousDatasetDetail"];
+                };
+            };
+        };
+    };
+    datasets_anonymous_timeseries_retrieve: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                public_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        [key: string]: {
+                            time?: string;
+                        }[];
+                    };
                 };
             };
         };


### PR DESCRIPTION
# 変更点
- `Dataset`モデルの`souce_file`が、`Dataset`インスタンス削除時に消去されるように変更
- 匿名ユーザーの`Dataset`インスタンスを、有効期限を超えたときに消去する関数を追加

## 備考
次回以降のPRで、時系列グラフのAPIおよびそのテストを追加する。